### PR TITLE
Fix resma serve and get_version callback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Thiago Campos <commit@thigcampos.com>", "Ivan Santiago <ivansantiago.junior@gmail.com>"]
 readme = "README.md"
+packages = [{include = "resma"}]
 
 [tool.poetry.scripts]
 resma = "resma.main:app"

--- a/resma/main.py
+++ b/resma/main.py
@@ -9,7 +9,7 @@ from typing import Annotated, Final
 
 import typer
 from jinja2 import Environment, FileSystemLoader
-from typer import Typer
+from typer import Context, Typer
 
 from resma import __version__
 
@@ -47,18 +47,22 @@ def validate_resma_project():
         raise typer.Abort()
 
 
-def get_version(flag):
+def get_version(flag: bool):
     if flag:
         print(__version__)
+        raise typer.Exit()
 
 
 @app.callback(invoke_without_command=True)
 def main(
+    ctx: Context,
     version: Annotated[
-        bool, typer.Option(callback=get_version, is_flag=True)
+        bool, typer.Option(callback=get_version, is_flag=True, is_eager=True)
     ] = False,
 ):
     """Resma CLI Static Site Generator"""
+    if ctx.invoked_subcommand:
+        return
     resma_command = typer.style('resma --help', fg=typer.colors.GREEN)
     print(f'Use {resma_command} to see the available commands')
 
@@ -203,8 +207,13 @@ class CustomHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 def serve(port: int = 8080):
     """Run a http server from public folder"""
     Handler = CustomHTTPRequestHandler
-
-    os.chdir('public')
+    try:
+        os.chdir('public')
+    except FileNotFoundError as e:
+        typer.secho('public folder not found', fg=typer.colors.RED)
+        resma_build = typer.style('resma build', fg=typer.colors.GREEN)
+        typer.secho(f'Run {resma_build} before running "resma serve" again')
+        raise typer.Abort() from e
 
     with socketserver.TCPServer(('', port), Handler) as httpd:
         typer.secho(

--- a/resma/main.py
+++ b/resma/main.py
@@ -195,10 +195,16 @@ class CustomHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if (
             not self.path.endswith('/')  # not a folder
+            and not Path(f'./{self.path}').is_dir()
             and 'static' not in self.path
             and 'styles' not in self.path
         ):
             self.path += '.html'
+        elif (
+            self.path.endswith('/')
+            and Path(f'./{self.path[:-1]}.html').exists()
+        ):
+            self.path = self.path[:-1] + '.html'  # remove trailing slash
 
         return super().do_GET()
 


### PR DESCRIPTION
### Issues
- Server was not handling well static files fetch;
- Server was handling differently if URL path ends with '/' or not;


As noticed by @thigcampos before, `resma serve` had the issues above. It happens that our previous "fix" was fixing nothing haha (maybe I cut out more code than I should, sorry). I think I've got this now, but can you try running the code from this branch on your environment to make sure? :heart:

Previous PR #17 

### Changes
- Fix our CustomHTTPRequestHandler
- add a `raise typer.Exit()` on the get_version callback, so it is not called on every command.
- correctly setup our package source in pyproject.toml, so only our main source is built into the package.