### PR TITLE
ci: testing more python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
 
     steps:
       - name: Checkout
@@ -13,10 +16,10 @@ jobs:
       - name: Installing Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: ${{ matrix.python-version }}
 
       - name: Installing poetry
-        run: pipx install --python python3.12 poetry
+        run: pipx install poetry
 
       - name: Installing dependencies
         run: poetry install


### PR DESCRIPTION
# Changes

We started the development with python 3.12, but we should support 3.13 in tests and CI as well.

It would be nice to support more python versions, but we use `tomllib`, which is only available on python 3.12, and I think it is okay for apps to have a smaller support range.