### PR TITLE
ci: Add testing on Windows and Mac OS.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,11 @@ jobs:
 
       - name: Running linters
         run: poetry run task lint
+        if: ${{ matrix.os == 'ubuntu' }}
 
       - name: Mypy checking
         run: poetry run task mypy
+        if: ${{ matrix.os == 'ubuntu'  }}
 
       - name: Running tests with pytest
         run: poetry run task test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
         python-version: ["3.12", "3.13"]
+        os: [ubuntu, windows, macos]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fix #32 (Quick Fix 😄)
Added an `os` matrix to the CI workflow to test on Ubuntu, Windows and Mac OS.