### PR TITLE
ci: Extract linting and mypy into extra job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,33 @@ name: Continous Integration
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Installing Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Installing poetry
+        run: pipx install poetry
+
+      - name: Installing dependencies
+        run: poetry install
+
+      - name: Running linters
+        run: poetry run task lint
+
+      - name: Mypy checking
+        run: poetry run task mypy
+
   test:
     runs-on: ${{ matrix.os }}-latest
     strategy:
@@ -24,14 +51,6 @@ jobs:
 
       - name: Installing dependencies
         run: poetry install
-
-      - name: Running linters
-        run: poetry run task lint
-        if: ${{ matrix.os == 'ubuntu' }}
-
-      - name: Mypy checking
-        run: poetry run task mypy
-        if: ${{ matrix.os == 'ubuntu'  }}
 
       - name: Running tests with pytest
         run: poetry run task test


### PR DESCRIPTION
> I just think one more thing should be done, the `Running linters` and `Mypy checking` steps do not need to run everytime, maybe we could do some checking like 
> ```
> if: ${{ matrix.os == 'ubuntu'  }}
> ```
>
> on those steps. What do you think? 
>
> If you know a nicer way, i would be glad to know! :grinning:
>
> _Originally posted by @ivansantiagojr in https://github.com/brasilisclub/resma/issues/33#issuecomment-2661074014_

How about extracting it into extra job (this PR).
            